### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/updater/download.go
+++ b/updater/download.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -57,11 +58,20 @@ func DownloadUpdateWithContext(ctx context.Context, downloadURL, destDir string)
 	return destPath, nil
 }
 
-func determineFilename(path string) string {
-	segments := strings.Split(path, "/")
-	fname := segments[len(segments)-1]
-	if fname == "" {
-		fname = fmt.Sprintf("sync-%d.bin", time.Now().Unix())
+func determineFilename(p string) string {
+	// Extract the last path component from the URL path.
+	base := path.Base(p)
+
+	// Generate a safe fallback name if the base is empty or clearly invalid.
+	generated := fmt.Sprintf("sync-%d.bin", time.Now().Unix())
+	if base == "" || base == "." || base == "/" {
+		return generated
 	}
-	return fname
+
+	// Ensure the filename is a single component without directory traversal.
+	if strings.Contains(base, "/") || strings.Contains(base, "\\") || strings.Contains(base, "..") {
+		return generated
+	}
+
+	return base
 }


### PR DESCRIPTION
Potential fix for [https://github.com/waldirborbajr/sync/security/code-scanning/2](https://github.com/waldirborbajr/sync/security/code-scanning/2)

In general, the fix is to ensure that any path component derived from untrusted data is safely normalized and validated before using it to construct a filesystem path. Specifically, for this code, `determineFilename` should enforce that the filename is a single component (no path separators or `..` segments) and fall back to a safe generated name if the path is empty or invalid. Additionally, when we join the filename with `destDir`, we should ensure that the resulting absolute path stays inside the intended safe directory.

The best targeted fix without altering existing behavior is:

1. Strengthen `determineFilename` in `updater/download.go`:
   - Extract just the last path segment using `path.Base` (from the standard library `path` package for URL-style paths).
   - If the result is empty or `"."`/`"/"`, or contains `..`, `/`, or `\`, treat it as invalid and instead return the existing generated fallback name (`sync-<timestamp>.bin`).
   - This ensures that even if an attacker supplies something like `../../etc/passwd` or `foo/bar`, the filename used on disk will be a benign generated name and not contain traversal characters.

2. Optionally (and safely) validate `destPath` in `DownloadUpdateWithContext`:
   - Compute `absDir, err := filepath.Abs(destDir)` and `absPath, err := filepath.Abs(destPath)`.
   - If `absPath` is not under `absDir` (e.g., `!strings.HasPrefix(absPath, absDir+string(os.PathSeparator))`), return an error.
   - This guarantees that the destination file stays inside the designated update directory, even if `destDir` were misconfigured.

Given your constraints, we can implement (1) entirely within the shown snippet of `updater/download.go` by importing `path` and updating `determineFilename`. That alone fully addresses the specific CodeQL flow (the path from `resp.Request.URL.Path` to the filesystem), because the tainted URL path can no longer influence directories or traversal; it only influences, at worst, the base filename or is replaced by a generated safe name. No changes to `updater/install.go` or `updater/manager.go` are needed.

Concretely:

- Edit `updater/download.go`:
  - Add `path` to the imports.
  - Replace the body of `determineFilename` with logic that:
    - Uses `path.Base` on the URL path.
    - If the extracted name is empty or invalid (contains `/`, `\`, or `..`), returns the generated fallback name.
    - Otherwise returns the sanitized name.

This keeps the external behavior equivalent for normal, well-formed update URLs (they still result in the same last path segment filename) while blocking dangerous patterns.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
